### PR TITLE
Fix cannot parse version `1.8.0 ; ttfautohint (v1.8.2)`

### DIFF
--- a/internal/fontforge/font.go
+++ b/internal/fontforge/font.go
@@ -2,6 +2,7 @@ package fontforge
 
 import (
 	"regexp"
+	"strings"
 
 	"github.com/Masterminds/semver/v3"
 
@@ -270,6 +271,8 @@ var buildPattern = regexp.MustCompile(`\s+build\s+(\d+)$`)
 
 func parseVersion(v string) *semver.Version {
 	// Sanitize the version.
+	v, _, _ = strings.Cut(v, ";")
+	v = strings.TrimSpace(v)
 	v = buildPattern.ReplaceAllString(v, "+$1")
 
 	r, _ := semver.NewVersion(v) //nolint: errcheck


### PR DESCRIPTION
## Description

Fix cannot parse version `1.8.0 ; ttfautohint (v1.8.2)`